### PR TITLE
Description of choke point CP 2.3

### DIFF
--- a/design/ChokePoints.md
+++ b/design/ChokePoints.md
@@ -18,7 +18,21 @@ One of the main innovations of GraphQL in comparison to REST APIs is that it all
 
 ### CP 2.2: 
 
-### CP 2.3: 
+### CP 2.3: Relationship traversal with and without retrieval of intermediate object data
+In addition to traversing along multiple relationships, GraphQL allows users to retrieve attributes (scalar fields) of the objects that are visited during the traversal. As an example, consider the following GraphQL query.
+
+```
+query {
+  person(name:″Alice″) {
+    knows {
+      name
+      reviewedBooks { title }
+    }
+  }
+}
+```
+
+This query does not only retrieve the titles of the books reached via the traversal, but also the names of the persons that are visited when traversing to the books. This choke point captures how efficient a system is in retrieving multiple attributes of such intermediate object data.
 
 ### CP 2.4: 
 

--- a/design/ChokePoints.md
+++ b/design/ChokePoints.md
@@ -23,7 +23,7 @@ In addition to traversing along multiple relationships, GraphQL allows users to 
 
 ```
 query {
-  person(name:″Alice″) {
+  person(name:"Alice") {
     knows {
       name
       reviewedBooks { title }
@@ -32,7 +32,7 @@ query {
 }
 ```
 
-This query does not only retrieve the titles of the books reached via the traversal, but also the names of the persons that are visited when traversing to the books. This choke point captures how efficient a system is in retrieving multiple attributes of such intermediate object data.
+This query does not only retrieve the titles of the books that are reached via the traversal. Instead, the query also retrieves the names of the persons that are visited when traversing to the books. In more general terms, this query does not only traverse from some starting node (such as the Alice object in the example) to some target nodes (the books) and then retrieve some attributes of these target nodes (the book titles). Instead, the additional aspect of this query that is important for this choke point is that the query requests attributes of objects that are along the way of the traversal. Hence, the challenge here is not only to be able to traverse efficiently (without looking at the intermediate objects along the way)--which is something that is already captured by choke points CP 2.1 and CP 2.2--but also to be able to efficiently access the attributes of objects that we "pass by" during the traversal.
 
 ### CP 2.4: 
 


### PR DESCRIPTION
The purpose of this PR is to discuss the following one of [our choke points](https://github.com/LiUGraphQL/LinGBM/wiki/Choke-Points-for-a-GraphQL-Performance-Benchmark).

### CP 2.3: Relationship traversal with and without retrieval of intermediate object data
In addition to traversing along multiple relationships, GraphQL allows users to retrieve attributes (scalar fields) of the objects that are visited during the traversal. As an example, consider the following GraphQL query.

```
query {
  person(name:″Alice″) {
    knows {
      name
      reviewedBooks { title }
    }
  }
}
```

This query does not only retrieve the titles of the books reached via the traversal, but also the names of the persons that are visited when traversing to the books. This choke point captures how efficient a system is in retrieving multiple attributes of such intermediate object data.