### PR TITLE
Description of choke point CP 4.4

### DIFF
--- a/design/ChokePoints.md
+++ b/design/ChokePoints.md
@@ -54,7 +54,20 @@ Field arguments in GraphQL queries are powerful not only because they can be use
 
 ### CP 4.3: 
 
-### CP 4.4: 
+### CP 4.4: Subquery-based search
+While the previous choke point focuses explicitly on cases in which a subquery-based filter condition has to be applied somewhere along a relationship traversal, it is also possible to use such subqueries as field arguments of the main query object (like in the string matching example given above). For instance, the following query searches for persons who have reviewed a movie that was reviewed by Alice and, for each such person, retrieves the persons that they know.
+
+```
+query {
+  person(where:{reviewedMovies:{reviewedBy:{name:″Alice″}}}) {
+    knows {
+      name
+    }
+  }
+} 
+```
+
+Such a usage of subqueries captures more a notion of query-based search for candidate objects rather than filtering. While techniques to perform a subquery-based filtering (as captured by the previous choke point) may also be employed for subquery-based search, some systems may be equipped with techniques that focus especially on only one of the two variants of using subqueries in field arguments. Therefore, we consider subquery-based search as an additional choke point (separate from the previous one about subquery-based filtering).
 
 ### CP 4.5: 
 


### PR DESCRIPTION
The purpose of this PR is to discuss the following one of [our choke points](https://github.com/LiUGraphQL/LinGBM/wiki/Choke-Points-for-a-GraphQL-Performance-Benchmark).

### CP 4.4: Subquery-based search
While the previous choke point focuses explicitly on cases in which a subquery-based filter condition has to be applied somewhere along a relationship traversal, it is also possible to use such subqueries as field arguments of the main query object (like in the string matching example given above). For instance, the following query searches for persons who have reviewed a movie that was reviewed by Alice and, for each such person, retrieves the persons that they know.

```
query {
  person(where:{reviewedMovies:{reviewedBy:{name:″Alice″}}}) {
    knows {
      name
    }
  }
} 
```

Such a usage of subqueries captures more a notion of query-based search for candidate objects rather than filtering. While techniques to perform a subquery-based filtering (as captured by the previous choke point) may also be employed for subquery-based search, some systems may be equipped with techniques that focus especially on only one of the two variants of using subqueries in field arguments. Therefore, we consider subquery-based search as an additional choke point (separate from the previous one about subquery-based filtering).