### PR TITLE
Description of choke point CP 5.2

### DIFF
--- a/design/ChokePoints.md
+++ b/design/ChokePoints.md
@@ -63,4 +63,6 @@ Another advanced feature that GraphQL APIs may provide is to execute aggregation
 
 ### CP 5.1: 
 
-### CP 5.2: 
+### CP 5.2: Counting
+This choke point focuses on the aggregation function that counts the number of elements in a set of data objects or values. In contrast to the previous choke point, the challenge in this case is to recognize that the objects/values may not actually have to be retrieved from the underlying data source in order to count them.
+


### PR DESCRIPTION
The purpose of this PR is to discuss the following one of [our choke points](https://github.com/LiUGraphQL/LinGBM/wiki/Choke-Points-for-a-GraphQL-Performance-Benchmark).

### CP 5.2: Counting
This choke point focuses on the aggregation function that counts the number of elements in a set of data objects or values. In contrast to the previous choke point, the challenge in this case is to recognize that the objects/values may not actually have to be retrieved from the underlying data source in order to count them.
