### PR TITLE
QT11 - comments -> comment

### DIFF
--- a/querygen/queryTemplate/template11/queryTemplate11.txt
+++ b/querygen/queryTemplate/template11/queryTemplate11.txt
@@ -4,6 +4,6 @@ query subquerySearch($vendorID:ID)
   	{
     	price
     	offerWebpage
-    	product {label comments}
+    	product {label comment}
   	}
 }


### PR DESCRIPTION
The schema specifies that a product has a comment field, not a comments field. So changed it in the queryTemplate.